### PR TITLE
Changed default maximum rs value

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ train_model(model, train_imgs, train_labels, arch_label, data_label, batch_size,
 * batch_size (default: 32) - Number of images per training batch
 * epochs (default: 10) - Number of times to train the model on the entire dataset
 * num_rs_bins (default: 32) - Number of bins to use in model output
-* max_rs_val (default: 3.5) - Maximum expected redshift value. Necessary for categorical conversion
+* max_rs_val (default: 0.4) - Maximum expected redshift value. Necessary for categorical conversion
 * val_split (default: 0.15) - Percentage of samples to hold out for validation
 * rot_chance (default: 0.4): Probability for each image to be individually flipped after each epoch (randomly chooses axis to flip across)
     * flip_chance (default: 0.2): Probability for each image to be individually rotated after each epoch (randomly chooses degree of rotation)

--- a/model/eval_model.py
+++ b/model/eval_model.py
@@ -183,7 +183,7 @@ def main(mode=0):
 
     image_shape = (64,64,5)
     num_classes = 32
-    max_val = 3.5
+    max_val = 0.4
 
     if mode == 0:
         models = [

--- a/train-test.py
+++ b/train-test.py
@@ -14,7 +14,7 @@ with open(train_data_file,'rb') as pkl:
 image_shape = (64,64,5)
 num_classes = 32
 epochs = 20
-max_val=3.5
+max_val=0.4
 
 models = [
     RedshiftClassifierResNet(image_shape, num_classes),

--- a/train.py
+++ b/train.py
@@ -47,7 +47,7 @@ class ImageSequence(Sequence):
         self.x = np.array([self.mutate(i) for i in self.x])
 
 class Train():
-    def __init__(self, batch_size=32, epochs=10, val_split=0.15, num_bins=32, max_val=3.5):
+    def __init__(self, batch_size=32, epochs=10, val_split=0.15, num_bins=32, max_val=0.4):
         """Trainer object for training a keras model. Specialized for redshift estimation.
         
         Args:
@@ -122,7 +122,7 @@ def train_model(model,
                 batch_size=32,
                 epochs=10,
                 num_rs_bins=32,
-                max_rs_val=3.5,
+                max_rs_val=0.4,
                 val_split=0.15,
                 rot_chance=0.4,
                 flip_chance=0.2):
@@ -141,7 +141,7 @@ def train_model(model,
         num_rs_bins (int, optional): Number of bins to use in model output (generates a pdf of this
             length). Defaults to 32.
         max_rs_val (float, optional): Maximum expected redshift value. Necessary for categorical
-            conversion. Defaults to 3.5.
+            conversion. Defaults to 0.4.
         val_split (float, optional): Percent of the data to use for validation. Defaults to 0.15.
         rot_chance (float, optional): Probability for each image to be individually flipped after
             each epoch (randomly chooses axis to flip across). Defaults to 0.4.


### PR DESCRIPTION
Changes the default maximum redshift value from 3.5 to 0.4, which is in line with the original experiment. Fixes #38 